### PR TITLE
Set workdir in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ RUN cargo build --release
 
 FROM gcr.io/distroless/cc-debian12
 COPY --from=builder /app/target/release/offercode /app/offer-codes
+WORKDIR /app
 ENTRYPOINT ["/app/offer-codes"]


### PR DESCRIPTION
dotenv looks in the current directory by default for the dotenv file. Which isn't necessarily the same directory that the executable is in. So just explicitly setting the current working directory to the directory that the binary and .env will be in.