### PR TITLE
Add minimum-release-age to prevent supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440


### PR DESCRIPTION
See https://chia-network.atlassian.net/browse/SEC-1019 and #security_chat for context

## Summary

Adds `minimum-release-age=1440` to `.npmrc`, which tells pnpm to only resolve package versions published more than 1 day (1440 minutes) ago. Most malicious package versions are detected and yanked within hours, so a 24-hour delay filters out smash-and-grab supply chain attacks.

### Note on pnpm version

This setting requires pnpm >= 10.16 (introduced September 2025). The repo currently uses `pnpm@10.6.5` via the `packageManager` field, so the setting will be silently ignored until pnpm is upgraded. Consider updating `packageManager` to `pnpm@10.33.4` (latest 10.x) or `pnpm@11.x` (which defaults to 1440 minutes out of the box).

Made with [Cursor](https://cursor.com)